### PR TITLE
Use proper config file name for init

### DIFF
--- a/src/malaby.js
+++ b/src/malaby.js
@@ -45,7 +45,7 @@ const currentVersion = require('../package').version;
     }
 
     if (isInitCommand) {
-        createConfigFile(configPath);
+        createConfigFile(configPath || path.join(CWD, 'malaby-config.json'));
         return;
     }
 


### PR DESCRIPTION
This should fix failure of `malaby init` (https://github.com/segevofer/malaby/issues/5)